### PR TITLE
bugfix

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -19,6 +19,7 @@
   "youtube": {
     "channel_name": "",
     "channel_id": "",
+    "video_id": "",
     "area_v2": 235,
     "quality": "best"
   },

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,8 @@ pub struct Youtube {
     #[serde(default)]
     pub channel_id: String,
     #[serde(default)]
+    pub video_id: String,
+    #[serde(default)]
     pub area_v2: u64,
     #[serde(default = "default_quality")]
     pub quality: String,
@@ -228,6 +230,8 @@ pub async fn load_config() -> Result<Config, Box<dyn Error>> {
             channel_name: String,
             #[serde(rename = "ChannelId", default)]
             channel_id: String,
+            #[serde(rename = "VideoId", default)]
+            video_id: String,
             #[serde(rename = "Area_v2", default)]
             area_v2: u64,
             #[serde(rename = "Quality", default = "default_quality")]
@@ -260,6 +264,7 @@ pub async fn load_config() -> Result<Config, Box<dyn Error>> {
             youtube: Youtube {
                 channel_name: legacy.youtube.channel_name,
                 channel_id: legacy.youtube.channel_id,
+                video_id: legacy.youtube.video_id,
                 area_v2: legacy.youtube.area_v2,
                 quality: legacy.youtube.quality,
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use riven::consts::PlatformRoute;
 use riven::RiotApi;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
-use std::{error::Error, thread, time::Duration};
+use std::{error::Error, thread, time::Duration, env};
 use textwrap;
 use tracing_subscriber::fmt;
 use unicode_width::UnicodeWidthStr;
@@ -209,7 +209,7 @@ async fn run_bilistream(ffmpeg_log_level: &str) -> Result<(), Box<dyn std::error
                 (
                     "YT",
                     cfg.youtube.channel_name.clone(),
-                    cfg.youtube.channel_id.clone(),
+                    cfg.youtube.video_id.clone(),
                     cfg.youtube.area_v2,
                     format!("【转播】{}", cfg.youtube.channel_name),
                 )
@@ -292,7 +292,7 @@ async fn run_bilistream(ffmpeg_log_level: &str) -> Result<(), Box<dyn std::error
                 continue 'outer;
             }
             // Reuse bili_is_live, bili_title, bili_area_id from earlier check (line 200)
-            if !bili_is_live && (area_v2 != 86 || !INVALID_ID_DETECTED.load(Ordering::SeqCst)) {
+            if env::var_os("bili_ffmepg_down").is_none() && !bili_is_live && (area_v2 != 86 || !INVALID_ID_DETECTED.load(Ordering::SeqCst)) {
                 tracing::info!("B站未直播");
                 let area_name = get_area_name(area_v2);
                 bili_start_live(&mut cfg, area_v2).await?;
@@ -319,7 +319,7 @@ async fn run_bilistream(ffmpeg_log_level: &str) -> Result<(), Box<dyn std::error
                         tracing::warn!("跳过封面更新：缩略图下载失败");
                     }
                 }
-            } else {
+            } else if env::var_os("bili_ffmepg_down").is_none() {
                 // 如果target channel改变，则变更B站直播标题
                 if bili_title != cfg_title {
                     bili_change_live_title(&cfg, &cfg_title).await?;
@@ -1461,6 +1461,7 @@ async fn setup_wizard() -> Result<(), Box<dyn std::error::Error>> {
         youtube: Youtube {
             channel_name: yt_channel_name,
             channel_id: yt_channel_id,
+            video_id: String::new(),
             area_v2: yt_area_v2,
             quality: yt_quality,
         },

--- a/src/plugins/live.rs
+++ b/src/plugins/live.rs
@@ -107,7 +107,7 @@ pub async fn get_thumbnail(
         .arg("--convert-thumbnails")
         .arg("jpg")
         .arg(match platform {
-            "YT" => format!("https://www.youtube.com/channel/{}/live", channel_id),
+            "YT" => format!("https://www.youtube.com/watch?v={}", channel_id),
             "TW" => format!("https://www.twitch.tv/{}", channel_id),
             _ => return Err("Unsupported platform".into()),
         })

--- a/src/webui/api.rs
+++ b/src/webui/api.rs
@@ -635,6 +635,7 @@ pub async fn save_setup_config(
             youtube: crate::config::Youtube {
                 channel_name: String::new(),
                 channel_id: String::new(),
+                video_id: String::new(),
                 area_v2: 235,
                 quality: "best".to_string(),
             },


### PR DESCRIPTION
bugfix:
1.yt-dlp cannot directly redirect from channel URL to video URL.
2.yt-dlp -f cannot directly process other resolutions.
3.The URL obtained by ffmpeg contains extra newline characters, causing the stream to fail.
4.add an environment variable named "bili_ffmepg_down" for testing push stream commands.