### PR TITLE
Fix false ffmpeg stuck detection from padded speed output

### DIFF
--- a/src/plugins/ffmpeg.rs
+++ b/src/plugins/ffmpeg.rs
@@ -407,14 +407,22 @@ fn extract_compact_stats(line: &str) -> Option<(String, Option<f32>, Option<u32>
 
         let mut speed_value: Option<f32> = None;
         let mut time_value: Option<u32> = None;
+        let parts: Vec<&str> = stats_from_time.split_whitespace().collect();
 
         // Quick parse for speed and time values (for stuck detection)
-        for part in stats_from_time.split_whitespace() {
+        for (idx, part) in parts.iter().enumerate() {
             if let Some(value) = part.strip_prefix("time=") {
                 time_value = parse_time_to_seconds(value);
             } else if let Some(value) = part.strip_prefix("speed=") {
-                // Parse speed value (remove 'x' suffix if present)
-                let clean_value = value.trim_end_matches('x');
+                // Handle both formats:
+                // - "speed=0.99x" (single token)
+                // - "speed=   1x" (value is in next token because of padding)
+                let speed_token = if value.is_empty() {
+                    parts.get(idx + 1).copied().unwrap_or("")
+                } else {
+                    value
+                };
+                let clean_value = speed_token.trim_end_matches('x');
                 if let Ok(parsed) = clean_value.parse::<f32>() {
                     speed_value = Some(parsed);
                 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix ffmpeg stats parsing to correctly read speed when ffmpeg outputs padded format like `speed=   1x`
- ensure low-speed tracking is reset whenever speed recovers, so the "below threshold for 30s" check is truly continuous
- preserve existing behavior for standard compact format like `speed=0.838x`

## Root cause
`extract_compact_stats` split the line by whitespace and parsed only the token containing `speed=`. For padded output, that token becomes `speed=` and the numeric value (`1x`) is in the next token, so speed parsing failed and `LOW_SPEED_SINCE` was not reset.

## Validation
- inspected and patched `src/plugins/ffmpeg.rs` parser logic
- attempted `cargo check`, but environment toolchain is too old (`cargo 1.83.0`) for dependencies requiring `edition2024` in this workspace, so full compile validation could not run here
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ddf0e88-5304-4c81-ba5d-8e8f806f3cef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ddf0e88-5304-4c81-ba5d-8e8f806f3cef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

